### PR TITLE
riya - create helpreq controller, add GET /all and POST methods

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestsController.java
@@ -1,0 +1,100 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a REST controller for HelpRequests
+ */
+
+@Tag(name = "HelpRequests")
+@RequestMapping("/api/helprequests")
+@RestController
+@Slf4j
+
+public class HelpRequestsController extends ApiController {
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    /**
+     * List all Help Requests
+     * 
+     * @return an iterable of HelpRequest
+     */
+    @Operation(summary = "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        Iterable<HelpRequest> helpRequests = helpRequestRepository.findAll();
+        return helpRequests;
+    }
+
+    /**
+     * Create a new help request
+     * 
+     * @param requesterEmail      email of person requesting help
+     * @param teamId              year, team number, and section of person
+     *                            requesting help
+     * @param tableOrBreakoutRoom the table or breakout room the requester is at
+     * @param requestTime         what date/time the request was put in
+     * @param explanation         description of the issue
+     * @param solved              if the issue has been solved or not
+     * @return the saved help request
+     */
+    @Operation(summary = "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @Parameter(name = "requesterEmail") @RequestParam String requesterEmail,
+            @Parameter(name = "teamId") @RequestParam String teamId,
+            @Parameter(name = "tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @Parameter(name = "requestTime", description = "requestTime") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @Parameter(name = "explanation") @RequestParam String explanation,
+            @Parameter(name = "solved") @RequestParam Boolean solved)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,34 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents a Help Request
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequests")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String requesterEmail;
+  private String teamId;
+  private String tableOrBreakoutRoom;
+  private LocalDateTime requestTime;
+  private String explanation;
+  private boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The HelpRequestRepository is a repository for HelpRequest entities.
+ */
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+  
+}

--- a/src/main/resources/db/migration/changes/HelpRequests.json
+++ b/src/main/resources/db/migration/changes/HelpRequests.json
@@ -1,0 +1,80 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "HelpRequests-1",
+          "author": "RiyaGupta1234",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "HELPREQUESTS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "HELPREQUESTS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUESTER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TEAM_ID",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "TABLE_OR_BREAKOUT_ROOM",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REQUEST_TIME",
+                      "type": "TIMESTAMP"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "EXPLANATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "SOLVED",
+                      "type": "BOOLEAN"
+                    }
+                  }
+                ],
+                "tableName": "HELPREQUESTS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,152 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UCSBDateRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestsController.class)
+@Import(TestConfig.class)
+
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+    @MockBean
+    HelpRequestRepository helpRequestRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().is(200)); // logged
+    }
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/helprequests/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/helprequests/post"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_can_get_all_help_requests() throws Exception {
+
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2025-01-03T00:00:00");
+
+        HelpRequest helpRequest1 = HelpRequest.builder()
+                .requesterEmail("riyagupta@ucsb.edu")
+                .teamId("s25-6pm-6")
+                .tableOrBreakoutRoom("6")
+                .requestTime(ldt1)
+                .explanation("testing")
+                .solved(true)
+                .build();
+
+        LocalDateTime ldt2 = LocalDateTime.parse("2022-03-11T00:00:00");
+
+        HelpRequest helpRequest2 = HelpRequest.builder()
+                .requesterEmail("yarwinliu@ucsb.edu")
+                .teamId("s25-6pm-4")
+                .tableOrBreakoutRoom("4")
+                .requestTime(ldt2)
+                .explanation("testing2")
+                .solved(false)
+                .build();
+
+        ArrayList<HelpRequest> expectedHelpRequests = new ArrayList<>();
+        expectedHelpRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+        when(helpRequestRepository.findAll()).thenReturn(expectedHelpRequests);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/helprequests/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(helpRequestRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedHelpRequests);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void an_admin_user_can_post_a_new_help_request() throws Exception {
+        // arrange
+
+        LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        HelpRequest helpRequest1 = HelpRequest.builder()
+                .requesterEmail("riyagupta@ucsb.edu")
+                .teamId("s25-6pm-6")
+                .tableOrBreakoutRoom("6")
+                .requestTime(ldt1)
+                .explanation("testing")
+                .solved(true)
+                .build();
+
+        when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/helprequests/post?requesterEmail=riyagupta@ucsb.edu&teamId=s25-6pm-6&tableOrBreakoutRoom=6&requestTime=2022-01-03T00:00:00&explanation=testing&solved=true")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(helpRequestRepository, times(1)).save(eq(helpRequest1));
+        String expectedJson = mapper.writeValueAsString(helpRequest1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+}


### PR DESCRIPTION
Closes #33 

In this PR, we add a GET /all for help requests and a POST to create a help request.
<img width="1470" alt="Screenshot 2025-04-23 at 5 56 19 PM" src="https://github.com/user-attachments/assets/8849a643-db41-41bd-a38d-9d4fc99e483a" />
