### PR TITLE
yl - create database table for MenuItemReviews

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <!-- (21) <properties/> -->
 
   <properties>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <mainClass>edu.ucsb.cs156.example.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.example</app.package>
     <app.packagePath>edu/ucsb/cs156/example</app.packagePath>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <!-- (21) <properties/> -->
 
   <properties>
-    <java.version>21</java.version>
+    <java.version>17</java.version>
     <mainClass>edu.ucsb.cs156.example.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.example</app.package>
     <app.packagePath>edu/ucsb/cs156/example</app.packagePath>

--- a/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/MenuItemReview.java
@@ -1,0 +1,33 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * This is a JPA entity that represents menu item review, i.e. an entry
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "menuitemreview")
+public class MenuItemReview {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id; //id of the review itself, not the menu item being reviewed
+
+  long itemId; //id of the menu item being reviewed, not the review itself
+  private String reviewerEmail;
+  private int stars;
+  private String comments;
+  private LocalDateTime dateReviewed;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.entities.UCSBDate;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UCSBDateRepository is a repository for UCSBDate entities.
+ */
+
+@Repository
+public interface MenuItemReviewRepository extends CrudRepository<MenuItemReview, Long> { //database table of menu item reviews with key long
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/MenuItemReviewRepository.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.example.repositories;
 
 import edu.ucsb.cs156.example.entities.MenuItemReview;
-import edu.ucsb.cs156.example.entities.UCSBDate;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/resources/db/migration/changes/MenuItemReviews.json
+++ b/src/main/resources/db/migration/changes/MenuItemReviews.json
@@ -1,0 +1,74 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "MenuItemReview-1",
+          "author": "yarwinliu",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "MENUITEMREVIEWS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "MENUITEMREVIEWS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ITEM_ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "REVIEWER_EMAIL",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STARS",
+                      "type": "INTEGER"}
+                  },
+                  {
+                    "column": {
+                      "name": "COMMENTS",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DATE_REVIEWED",
+                      "type": "TIMESTAMP"
+                    }
+                  }
+
+                ],
+                "tableName": "MENUITEMREVIEWS"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
Closes #26 

create database table with these fields:

```
Long itemId (the id in the UCSBDiningCommonsMenuItems table of a menu item)
String reviewerEmail (the email of the reviewer)
int stars (0 to 5 stars)
LocalDateTime dateReviewed
String comments
```

can be tested by either
- running on localhost and looking for the MenuItemReview table on the h2-console (in the side bar)
- running on dokku and connecting to the postgres database using commands 
`dokku postgres:connect team01-dev-yarwinliu-db` 
`\db` 

